### PR TITLE
added check to solve the segfault when monitor closes on shutdown

### DIFF
--- a/ext/nio4r/monitor.c
+++ b/ext/nio4r/monitor.c
@@ -127,10 +127,13 @@ static VALUE NIO_Monitor_close(int argc, VALUE *argv, VALUE self)
     selector = rb_ivar_get(self, rb_intern("selector"));
 
     if(selector != Qnil) {
-        ev_io_stop(monitor->selector->ev_loop, &monitor->ev_io);
+        /* if ev_loop is 0, it means that the loop has been stopped already (see NIO_Selector_shutdown)*/
+        if(monitor->selector->ev_loop != 0) {
+          ev_io_stop(monitor->selector->ev_loop, &monitor->ev_io);
+        }
         monitor->selector = 0;
         rb_ivar_set(self, rb_intern("selector"), Qnil);
-
+    
         /* Default value is true */
         if(deregister == Qtrue || deregister == Qnil) {
             rb_funcall(selector, rb_intern("deregister"), 1, rb_ivar_get(self, rb_intern("io")));

--- a/spec/nio/monitor_spec.rb
+++ b/spec/nio/monitor_spec.rb
@@ -58,4 +58,12 @@ describe NIO::Monitor do
     expect(subject).to be_closed
     expect(selector.registered?(reader)).to be_falsey
   end
+
+  it "closes even if the selector has been shutdown" do
+    expect(subject).not_to be_closed
+    selector.close # forces shutdown
+    expect(subject).not_to be_closed
+    subject.close
+    expect(subject).to be_closed
+  end
 end


### PR DESCRIPTION
When the IO actors get terminated, the monitors failed to close in specific cases (the Task::TerminatedError), dumping a segmentation fault C stacktrace and aborting the ruby process. This was solved by ioquatix [here](https://github.com/celluloid/celluloid-io/pull/122) and patched with the Task::TerminatedError check [here](https://github.com/celluloid/celluloid-io/blob/master/lib/celluloid/io/reactor.rb#L52). This doesn't completely solve the issue IMO since the task terminated is not always equal to actor terminating, thereby potentially leaving a registered descriptor in some cases. This was hinted before somewhere in that the bug was probably from a C extension of nio4r. 

Good news: I think I found and patched the bug. I added a check to see whether the event loop associated with the monitor selector is still valid. When selectors get shutdown, the loop is destroyed and the pointer set to 0. So one only needs to check its value to see whether the event loop has been destroyed.

Now, I'm not sure exactly what triggers the selector being shutdown (I assume the event loop destruction happens [here](https://github.com/celluloid/nio4r/blob/master/ext/nio4r/selector.c#L130-L133). Maybe you can help me on that one.