### PR TITLE
Check for unistd.h

### DIFF
--- a/ext/nio4r/extconf.rb
+++ b/ext/nio4r/extconf.rb
@@ -1,5 +1,7 @@
 require 'mkmf'
 
+have_header('unistd.h')
+
 if have_func('rb_thread_blocking_region')
   $defs << '-DHAVE_RB_THREAD_BLOCKING_REGION'
 end

--- a/ext/nio4r/selector.c
+++ b/ext/nio4r/selector.c
@@ -7,7 +7,13 @@
 #ifdef HAVE_RUBYSIG_H
 # include "rubysig.h"
 #endif
+
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#else
+#include <io.h>
+#endif
+
 #include <fcntl.h>
 #include <assert.h>
 


### PR DESCRIPTION
The following patch allows nio4r to compile and install with MS Visual Studio. In short, it falls back to io.h if unistd.h isn't found.