### PR TITLE
Separate Selector#select return value for timeout/wakeup

### DIFF
--- a/ext/nio4r/nio4r.h
+++ b/ext/nio4r/nio4r.h
@@ -21,7 +21,7 @@ struct NIO_Selector
     struct ev_io wakeup;
 
     int wakeup_reader, wakeup_writer;
-    int closed, selecting;
+    int closed, selecting, timed_out;
     int ready_count;
 
     VALUE ready_array;

--- a/lib/nio/selector.rb
+++ b/lib/nio/selector.rb
@@ -61,7 +61,7 @@ module NIO
         end
 
         ready_readers, ready_writers = Kernel.select readers, writers, [], timeout
-        return unless ready_readers # timeout or wakeup
+        return unless ready_readers # timeout
 
         selected_monitors = Set.new
 
@@ -70,7 +70,7 @@ module NIO
             # Clear all wakeup signals we've received by reading them
             # Wakeups should have level triggered behavior
             @wakeup.read(@wakeup.stat.size)
-            return
+            return false
           else
             monitor = @selectables[io]
             monitor.readiness = :r


### PR DESCRIPTION
This PR is related to  #63.

Return values:
```
wakeup: false
timeout: nil
```

For pure implementation we return nil if Kernel.select returns nil, this does not handle spurious wakeups properly (they'd return `nil`), but after some research I'm not entirely sure that spurious wakeups *can* happen. If we decide it's important we could probably use the same approach that is used in the JRuby extension and time the `select()` call, if it returns early and the number of ready selectors is 0 then we have a wakeup.

For C implementation we return nil if the timed_out flag was set as part of the timeout timer, or if the busy loop determines we have timed out.

For Java implementation we calculate time spent waiting for select(), if it is longer than the specified timeout we assume that we have timed out.

I didn't manage to find a good way to test spurious wakeups. `Thread#wakeup` did not appear to cause `select()` to wake up at all.