### PR TITLE
Raise IOError if select called on closed selector.

### DIFF
--- a/ext/nio4r/org/nio4r/Nio4r.java
+++ b/ext/nio4r/org/nio4r/Nio4r.java
@@ -235,6 +235,11 @@ public class Nio4r implements Library {
         @JRubyMethod
         public synchronized IRubyObject select(ThreadContext context, IRubyObject timeout, Block block) {
             Ruby runtime = context.getRuntime();
+
+            if(!this.selector.isOpen()) {
+                throw context.getRuntime().newIOError("selector is closed");
+            }
+
             int ready = doSelect(runtime, context, timeout);
 
             /* Timeout or wakeup */

--- a/ext/nio4r/selector.c
+++ b/ext/nio4r/selector.c
@@ -297,6 +297,11 @@ static VALUE NIO_Selector_select_synchronized(VALUE *args)
     struct NIO_Selector *selector;
 
     Data_Get_Struct(args[0], struct NIO_Selector, selector);
+
+    if(selector->closed) {
+        rb_raise(rb_eIOError, "selector is closed");
+    }
+
     if(!rb_block_given_p()) {
         selector->ready_array = rb_ary_new();
     }

--- a/lib/nio/monitor.rb
+++ b/lib/nio/monitor.rb
@@ -33,6 +33,7 @@ module NIO
     end
     alias_method :writeable?, :writable?
 
+    # rubocop:disable TrivialAccessors
     # Is this monitor closed?
     def closed?
       @closed

--- a/lib/nio/selector.rb
+++ b/lib/nio/selector.rb
@@ -121,6 +121,7 @@ module NIO
       end
     end
 
+    # rubocop:disable TrivialAccessors
     # Is this selector closed?
     def closed?
       @closed

--- a/spec/nio/selector_spec.rb
+++ b/spec/nio/selector_spec.rb
@@ -161,6 +161,12 @@ RSpec.describe NIO::Selector do
       expect(readables).to include monitor2
       expect(readables).not_to include monitor3
     end
+
+    it "raises IOError if asked to select on a closed selector" do
+      subject.close
+
+      expect { subject.select(0) }.to raise_exception IOError
+    end
   end
 
   it "closes" do


### PR DESCRIPTION
Because exception is better than segfault.