### PR TITLE
Unneeded shebang in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-#!/usr/bin/env rake
 require "bundler/gem_tasks"
 require "rake/clean"
 


### PR DESCRIPTION
I found that shebang "#!/usr/bin/env rake" in nio4r Rakefile.
I think that if the shebang exists in the file, that means that file is executable.
But actually Rakefile is not used as executable.
So, in this case, we can remove the shebang "#!/usr/bin/env rake" in Rakefile.

Could you check it?
Best,
Jun Aruga