### PR TITLE
Use nonblocking writes to the waker pipe (fixes #100)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ rvm:
   - 2.2
   - 2.3.1
   - ruby-head
-  - jruby-1.7
   - jruby-9.0.5.0 # latest travis-ci preinstalled version
   - jruby-head
   - rbx

--- a/ext/nio4r/selector.c
+++ b/ext/nio4r/selector.c
@@ -93,7 +93,9 @@ static VALUE NIO_Selector_allocate(VALUE klass)
         rb_sys_fail("pipe");
     }
 
-    if(fcntl(fds[0], F_SETFL, O_NONBLOCK) < 0) {
+    /* Use non-blocking reads/writes during wakeup, in case the buffer is full */
+    if(fcntl(fds[0], F_SETFL, O_NONBLOCK) < 0 ||
+       fcntl(fds[1], F_SETFL, O_NONBLOCK) < 0) {
         rb_sys_fail("fcntl");
     }
 


### PR DESCRIPTION
If the waker pipe is full, we know the other thread has already been signaled, so we can ignore the failed write.