### PR TITLE
Fix build on OS X 10.11 with Ruby 2.3

### DIFF
--- a/ext/libev/ev.c
+++ b/ext/libev/ev.c
@@ -39,6 +39,7 @@
 
 /* ########## NIO4R PATCHERY HO! ########## */
 #include "ruby.h"
+#include "ruby/thread.h"
 /* ######################################## */
 
 /* this big block deduces configuration from config.h */


### PR DESCRIPTION
I tried installing `nio4r` on OS X 10.11 today and got the following compilation error:

    ../../../../ext/nio4r/../libev/ev.c:3737:9: error: implicit declaration of function 'rb_thread_call_without_gvl' is invalid in C99 [-Werror,-Wimplicit-function-declaration]

The problem seems to be that `rb_thread_call_without_gvl` is declared in `ruby/thread.h`, while the patched libev bundled with nio4r only includes `ruby.h`. This pull request adds the missing include, which allowed me to install nio4r successfully.