### PR TITLE
Travis: Build on jruby-9.1.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ env:
   - NIO4R_PURE=true
 
 matrix:
+  include:
+    - rvm: jruby-9.1.5.0
+      env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"      
+    - rvm: jruby-head
+      env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"      
   fast_finish: true
   allow_failures:
     - os:  osx # TODO: make tests pass reliably on OS X

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,13 @@ rvm:
   - rbx
 
 env:
-  - NIO4R_PURE=false
-  - NIO4R_PURE=true
+  global:
+    - JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"      
+  matrix:
+    - NIO4R_PURE=false
+    - NIO4R_PURE=true
 
 matrix:
-  include:
-    - rvm: jruby-9.1.5.0
-      env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"      
-    - rvm: jruby-head
-      env: JRUBY_OPTS="--dev -J-Djruby.launch.inproc=true -J-Xmx1024M"      
   fast_finish: true
   allow_failures:
     - os:  osx # TODO: make tests pass reliably on OS X

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ rvm:
   - 2.2
   - 2.3.1
   - ruby-head
-  - jruby-9.0.5.0 # latest travis-ci preinstalled version
+  - jruby-9.1.5.0 # latest stable
   - jruby-head
   - rbx
 


### PR DESCRIPTION
The current builds on jruby-9.0.5.0 fail.

This PR proposes to run builds on latest release of jruby.