### PR TITLE
Travis: jruby-9.1.6.0, pruned jruby-17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ rvm:
   - 2.2
   - 2.3.1
   - ruby-head
-  - jruby-9.1.5.0 # latest stable
+  - jruby-9.1.6.0 # latest stable
   - jruby-head
   - rbx
 
@@ -36,9 +36,7 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: rbx
-    - rvm: jruby-1.7
-      env: NIO4R_PURE=true
-    - rvm: jruby-9.1
+    - rvm: jruby-9.1.6.0
       env: NIO4R_PURE=true
 
 notifications:


### PR DESCRIPTION
This PR changes the Travis build matrix: use jruby-9.1.6.0.

Also: drops a not-run `jruby-17` from allowed failures.

(Builds green!)