### PR TITLE
Rubocop: target 2.2, add cop names on failures

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,10 @@
 # Deliberate style choices
 #
 
+AllCops:
+  TargetRubyVersion: 2.2
+  DisplayCopNames: true
+
 LineLength:
   Max: 100
 


### PR DESCRIPTION
Configuration PR which adds the `--display-cop-names` as always-on.

Also set 2.2 as target version of Ruby in Rubocop.