### PR TITLE
Remove cruft required to support Ruby 1.8

### DIFF
--- a/ext/libev/ev.c
+++ b/ext/libev/ev.c
@@ -3566,7 +3566,6 @@ time_update (EV_P_ ev_tstamp max_block)
 }
 
 /* ########## NIO4R PATCHERY HO! ########## */
-#if defined(HAVE_RB_THREAD_BLOCKING_REGION) || defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL)
 struct ev_poll_args {
   struct ev_loop *loop;
   ev_tstamp waittime;
@@ -3579,16 +3578,13 @@ VALUE ev_backend_poll(void *ptr)
   struct ev_loop *loop = args->loop;
   backend_poll (EV_A_ args->waittime);
 }
-#endif
 /* ######################################## */
 
 int
 ev_run (EV_P_ int flags)
 {
 /* ########## NIO4R PATCHERY HO! ########## */
-#if defined(HAVE_RB_THREAD_BLOCKING_REGION) || defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL)
     struct ev_poll_args poll_args;
-#endif
 /* ######################################## */
 
 #if EV_FEATURE_API
@@ -3749,25 +3745,9 @@ rb_thread_unsafe_dangerous_crazy_blocking_region_end(...);
 #######################################################################
 */
 
-/*
-  simulate to rb_thread_call_without_gvl using rb_theread_blocking_region.
-  https://github.com/brianmario/mysql2/blob/master/ext/mysql2/client.h#L8
-*/
-
-#ifndef HAVE_RB_THREAD_CALL_WITHOUT_GVL
-#ifdef HAVE_RB_THREAD_BLOCKING_REGION
-#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
-  rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
-#endif
-#endif
-
-#if defined(HAVE_RB_THREAD_BLOCKING_REGION) || defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL)
         poll_args.loop = loop;
         poll_args.waittime = waittime;
         rb_thread_call_without_gvl(ev_backend_poll, (void *)&poll_args, RUBY_UBF_IO, 0);
-#else
-         backend_poll (EV_A_ waittime);
-#endif
 /*
 ############################# END PATCHERY ############################
 */

--- a/ext/nio4r/extconf.rb
+++ b/ext/nio4r/extconf.rb
@@ -2,14 +2,6 @@ require "mkmf"
 
 have_header("unistd.h")
 
-if have_func("rb_thread_blocking_region")
-  $defs << "-DHAVE_RB_THREAD_BLOCKING_REGION"
-end
-
-if have_func("rb_thread_call_without_gvl")
-  $defs << "-DHAVE_RB_THEREAD_CALL_WITHOUT_GVL"
-end
-
 $defs << "-DEV_USE_SELECT" if have_header("sys/select.h")
 
 $defs << "-DEV_USE_POLL" if have_header("poll.h")


### PR DESCRIPTION
All supported Rubies should be using more modern APIs. We can remove any cruft used to support Ruby 1.8 at this point.