### PR TITLE
Disambiguate wakeup vs timeout (fixes #63, #66)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,10 +11,6 @@ Lint/HandleExceptions:
 Lint/Loop:
   Enabled: false
 
-# TODO: fix this
-Lint/NonLocalExitFromIterator:
-  Enabled: false
-
 #
 # Metrics
 #

--- a/ext/nio4r/nio4r.h
+++ b/ext/nio4r/nio4r.h
@@ -17,7 +17,7 @@ struct NIO_Selector
     struct ev_io wakeup;
 
     int wakeup_reader, wakeup_writer;
-    int closed, selecting;
+    int closed, selecting, timed_out;
     int ready_count;
 
     VALUE ready_array;

--- a/lib/nio/selector.rb
+++ b/lib/nio/selector.rb
@@ -79,16 +79,13 @@ module NIO
         end
 
         ready_readers, ready_writers = Kernel.select readers, writers, [], timeout
-        return unless ready_readers # timeout or wakeup
+        return unless ready_readers # timeout
 
         ready_readers.each do |io|
           if io == @wakeup
             # Clear all wakeup signals we've received by reading them
             # Wakeups should have level triggered behavior
             @wakeup.read(@wakeup.stat.size)
-
-            # TODO: return something other than nil on wakeup
-            return
           else
             monitor = @selectables[io]
             monitor.readiness = :r
@@ -107,7 +104,7 @@ module NIO
         selected_monitors.each { |m| yield m }
         selected_monitors.size
       else
-        selected_monitors
+        selected_monitors.to_a
       end
     end
 

--- a/spec/nio/selector_spec.rb
+++ b/spec/nio/selector_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe NIO::Selector do
 
       thread = Thread.new do
         started_at = Time.now
-        expect(subject.select).to be_nil
+        expect(subject.select).to eq []
         Time.now - started_at
       end
 


### PR DESCRIPTION
This changes the semantics of NIO::Selector#select so wakeup events can always be distinguished from timeouts:

- select will now *only* return nil on timeout
- wakeup will now return an empty array (or 0 if a block is given)

This should hopefully avoid breakages in existing code while making it easy to disambiguate the timeout case versus a wakeup.